### PR TITLE
#104 マイページ以降の画面codeigniterへ以降

### DIFF
--- a/src/application/www/controllers/Mypage.php
+++ b/src/application/www/controllers/Mypage.php
@@ -1,0 +1,97 @@
+<?php
+// マイページ
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Mypage extends CI_Controller {
+  public function __construct()
+  {
+    parent::__construct();
+    $this->load->helper('url');
+    $this->load->model('Mypage_model');
+  }
+
+  // マイページの表示
+	public function index()
+	{
+    // $user_id = $_SESSION['id'];// ログイン中のユーザーのIDを取得（セッションから）
+    $user_id = "1"; //今は1と仮定
+    $user_data = $this->Mypage_model->fetch_userdata($user_id);// ログインしたユーザー情報呼び出し
+
+    $this->load->view('mypage/mypage_view',$user_data);
+	}
+
+  // スタンプページ１画面表示
+  public function stamppage()
+  {
+    $this->load->view('mypage/stamppage_view');
+  }
+
+  // ひらがな印刷画面表示
+  public function hiragana()
+  {
+    $this->load->view('mypage_print/hiragana_view');
+  }
+
+  // すうじ印刷画面表示
+  public function suzi()
+  {
+    $this->load->view('mypage_print/suzi_view');
+  } 
+
+  // うんぴつ印刷画面表示
+  public function unpitu()
+  {
+    $this->load->view('mypage_print/unpitu_view');
+  }
+
+  // 点つなぎ印刷画面表示
+  public function tentunagi()
+  {
+    $this->load->view('mypage_print/tentunagi_view');
+  }
+
+  // プログラミング印刷画面表示
+  public function programming()
+  {
+    $this->load->view('mypage_print/programming_view');
+  }  
+
+
+  // スタンプページ２画面表示
+  public function stamppage2()
+  {
+    $this->load->view('mypage/stamppage2_view');
+  }
+
+
+  // 会員情報の変更画面表示
+  public function kaiinjouhou_update()
+  {
+    $this->load->view('mypage/kaiinjouhou_update_view');
+  }
+
+  // パスワードの変更画面表示
+  public function passwordchange()
+  {
+    $this->load->view('mypage/passwordchange_view');
+  }
+
+  // パスワードの変更完了画面表示
+  public function passwordchangekanryo()
+  {
+    $this->load->view('mypage/passwordchangekanryo_view');
+  }
+
+  // 退会画面表示
+  public function taikai()
+  {
+    $this->load->view('mypage/taikai_view');
+  }
+
+  // 退会完了画面表示
+  public function taikaikanryo()
+  {
+    $this->load->view('mypage/taikaikanryo_view');
+  }
+
+}

--- a/src/application/www/models/Mypage_model.php
+++ b/src/application/www/models/Mypage_model.php
@@ -1,0 +1,21 @@
+<?php
+// マイページ
+class Mypage_model extends CI_Model {
+
+
+  public function __construct()
+  {
+    parent::__construct();
+    $this->load->database();
+  }
+
+  // ログインユーザーのデータを取得
+  public function fetch_userdata($user_id){
+    return $this->db->where('users_id',$user_id)
+                    ->where('users_deleted_at',null)
+                    ->get('users')
+                    ->row_array();
+  }
+
+
+}

--- a/src/application/www/views/Layout/footer_view.php
+++ b/src/application/www/views/Layout/footer_view.php
@@ -1,0 +1,16 @@
+<!-- ******************************** -->
+<!-- *******   footer共通化   ******* -->
+<!-- ******************************** -->
+
+<!-- フッター -->
+<footer>
+  <small>Copyright&copy; <a href="index.html">幼児無料プリントサイト　ぷちはぐ</a> All Rights Reserved.</small>
+  <span class="pr">《<a href="https://template-party.com/" target="_blank">Web Design:Template-Party</a>》</span>
+</footer>
+
+</div><!--/#container-->
+
+<!--ページの上部に戻る「↑」ボタン-->
+<p class="nav-fix-pos-pagetop">
+  <a href="#"><img src="<?php base_url(); ?>/topdist/images/pagetop.png" alt="PAGE TOP"></a>
+</p>

--- a/src/application/www/views/Layout/header_view.php
+++ b/src/application/www/views/Layout/header_view.php
@@ -1,0 +1,24 @@
+<!-- ******************************** -->
+<!-- *******    head共通化    ******* -->
+<!-- ******************************** -->
+
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="無料で利用できる幼児(3歳～6歳)向けの教育、プリントサービスです">
+<meta name="keywords" content="幼児教育,知育,無料プリント,子供プリント,ひらがな,印刷">
+
+<!-- Bootstrap -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+
+<!-- CSS -->
+<link rel="stylesheet" href="<?php base_url(); ?>/topdist/css/style.css">
+<link rel="stylesheet" href="<?php base_url(); ?>/topdist/css/slide.css">
+
+<!-- JS -->
+<script src="<?php base_url(); ?>/topdist/js/fixmenu_pagetop.js"></script>
+
+
+<link rel="preconnect" href="https://fonts.gstatic.com">
+<link href="https://fonts.googleapis.com/css2?family=Nunito&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/earlyaccess/nicomoji.css" rel="stylesheet" />

--- a/src/application/www/views/Layout/menu_view.php
+++ b/src/application/www/views/Layout/menu_view.php
@@ -1,0 +1,22 @@
+<!-- ******************************** -->
+<!-- *****  title・menu共通化  ****** -->
+<!-- ******************************** -->
+
+<!-- ロゴ -->
+<header>
+  <h1 id="logo">
+    <a href="<?php base_url(); ?>/Top"><img src="<?php base_url(); ?>/topdist/images/logo1.png" alt="幼児無料プリントサイトぷちはぐ"></a>
+  </h1>
+</header>
+
+<!-- メインメニュー -->
+<nav id="menubar">
+  <ul>
+    <li class="current"><a href="<?php base_url(); ?>/Top">Home</a></li>
+    <li><a href="signup.html">会員登録・ログイン</a></li>
+    <li><a href="print.html">プリントする</a></li>
+    <li><a href="oshirase.html">お知らせ・コラム</a></li>
+    <li><a href="aboutsite.html">このサイトについて・利用規約</a></li>
+    <li><a href="contact.html">お問い合わせ</a></li>
+  </ul>
+</nav>

--- a/src/application/www/views/Mypage/kaiinjouhou_update_view.php
+++ b/src/application/www/views/Mypage/kaiinjouhou_update_view.php
@@ -1,0 +1,277 @@
+<!-- ******************************** -->
+<!-- *******  会員情報の変更  ******* -->
+<!-- ******************************** -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>会員情報の変更｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+
+    <script>
+        //名前➁の登録ありの場合　ボタンの色と文字の表示を切り替えるjs
+
+        function button_click1() {
+            var kaiinjouhou_update_button1 = document.getElementById("kaiinjouhou_update_button1");
+            if (kaiinjouhou_update_button1.value == "登録なしへ変更") {
+                kaiinjouhou_update_button1.setAttribute('class', 'btn btn-success');
+                kaiinjouhou_update_button1.setAttribute("value", "追加");
+            } else if (kaiinjouhou_update_button1.value == "追加") {
+                kaiinjouhou_update_button1.setAttribute('class', 'btn btn-secondary');
+                kaiinjouhou_update_button1.setAttribute("value", "登録なしへ変更");
+
+            }
+        }
+
+        //名前➁の登録ありの場合　 フォーム表・非表示切り替えjs
+        function switching() {
+            var kaiinjouhou_update_button1_value = document.getElementById("kaiinjouhou_update_button1").value;
+            //※ここでのkaiinjouhou_update_button1のvalueは、function buton_clickの処理後に取得される
+
+            if (kaiinjouhou_update_button1_value == "追加") {
+                $('#kaiinjouhou_child2name_display').hide();
+                $('#kaiinjouhou-child2add').hide();
+                $('#child2birthday').hide();
+
+                //登録無しの文言のみ表示させる
+                $("#none-form1").show();
+            } else if (kaiinjouhou_update_button1_value == "登録なしへ変更") {
+                $('#none-form1').hide();
+                $('#kaiinjouhou_child2name_display').hide();
+
+                //お子さんの名前➁の入力フォームと誕生日のみ表示させる
+                $("#kaiinjouhou-child2add").show();
+                $("#child2birthday").show();
+            }
+        }
+    </script>
+</head>
+
+<body>
+
+    <div id="container">
+
+       <!-- ロゴ --><!-- メインメニュー -->
+       <?php $this->load->view('Layout/menu_view.php'); ?>      
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <h1 class="contCaption">MY DATA　UPDATE</h1>
+                <h2 class="contSubCaption">会員情報の変更</h2>
+                <div class="message-user-kaiin">
+                    <p>会員情報の変更を行います。<br> 各項目の入力・変更が完了いたしましたら、「確認する」ボタンを押してください。
+                    </p>
+                </div>
+                <div class="sectionHeader">
+                    <h2>基本情報</h2>
+                </div><!-- /.sectionHeader -->
+
+                <form action="" method="post">
+
+                    <div class="form-group row form-inline justify-content-center">
+                        <label for="username" class="col-sm-2 col-form-label font-weight-bold">ユーザー名<br>(保護者の名前)</label>
+                        <div class="col-xs-2">
+                            <input type=" text " id="username " class="form-control " placeholder="現在の名前を表示させる ">
+                        </div>
+                    </div>
+                    <div class="form-group row form-inline justify-content-center">
+                        <label for="email " class="col-sm-2 col-form-label font-weight-bold">メールアドレス</label>
+                        <div class="col-xs-2">
+                            <input type="email " class="form-control " id="email " placeholder="アドレスを表示させる ">
+                        </div>
+                    </div>
+
+                    <div class="form-group row form-inline justify-content-center">
+                        <label for="childname1 " class="col-sm-2 col-form-label font-weight-bold">お子さま1人目の名前</label>
+                        <div class="col-xs-2">
+                            <input type="text " id="childname1 " class="form-control " placeholder="名前を表示させる ">
+                        </div>
+                    </div>
+                    <div class="form-group row form-inline justify-content-center">
+                        <label for="childname1 " class="col-sm-2 col-form-label font-weight-bold">誕生日</label>
+                        <div class="form-group">
+                            <select class="form-control" 　name="year">
+                                <option value="">-</option>
+                                <option value="2015">2015</option>
+                                <option value="2016">2016</option>
+                                <option value="2017">2017</option>
+                                <option value="2018">2018</option>
+                                <option value="2019">2019</option>
+                                <option value="2020">2020</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <select class="form-control" 　name="month">
+                                <option value="">-</option>
+                                <option value="1">1</option>
+                                <option value="2">2</option>
+                                <option value="3">3</option>
+                                <option value="4">4</option>
+                                <option value="5">5</option>
+                                <option value="6">6</option>
+                                <option value="7">7</option>
+                                <option value="8">8</option>
+                                <option value="9">9</option>
+                                <option value="10">10</option>
+                                <option value="11">11</option>
+                                <option value="12">12</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <select class="form-control" 　name="day">
+                                <option value="">-</option>
+                                <option value="1">1</option>
+                                <option value="2">2</option>
+                                <option value="3">3</option>
+                                <option value="4">4</option>
+                                <option value="5">5</option>
+                                <option value="6">6</option>
+                                <option value="7">7</option>
+                                <option value="8">8</option>
+                                <option value="9">9</option>
+                                <option value="10">10</option>
+                                <option value="11">11</option>
+                                <option value="12">12</option>
+                                <option value="13">13</option>
+                                <option value="14">14</option>
+                                <option value="15">15</option>
+                                <option value="16">16</option>
+                                <option value="17">17</option>
+                                <option value="18">18</option>
+                                <option value="19">19</option>
+                                <option value="20">20</option>
+                                <option value="21">21</option>
+                                <option value="22">22</option>
+                                <option value="23">23</option>
+                                <option value="24">24</option>
+                                <option value="25">25</option>
+                                <option value="26">26</option>
+                                <option value="27">27</option>
+                                <option value="28">28</option>
+                                <option value="29">29</option>
+                                <option value="30">30</option>
+                                <option value="31">31</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-group row form-inline justify-content-center">
+                        <label for="childname2" class="col-sm-2 col-form-label font-weight-bold">お子さま2人目の名前</label>
+                        <div class="col-xs-2" 　id="kaiinjouhou_child2name_display">
+                            <span id="kaiinjouhou_child2name_display">
+                                <input type="text " id="child2name" class="form-control" placeholder="名前を表示させる">
+                            </span>
+                        </div>
+                        <span id="none-form1">
+                            <p class="kaiinjouhou_update_center">登録無し</p>
+                        </span>
+                        <div class="col-xs-2" id="kaiinjouhou-child2add">
+                            <input type=" text " id="child2addname" class="form-control " placeholder="お子さんの名前➁を入力してください ">
+                        </div>
+                    </div>
+
+                    <div class="form-group row form-inline justify-content-center" id="child2birthday">
+                        <label for="child2birthday" class="col-sm-2 col-form-label font-weight-bold">誕生日</label>
+                        <div class="form-group">
+                            <select class="form-control" 　name="year">
+                                <option value="">-</option>
+                                <option value="2015">2015</option>
+                                <option value="2016">2016</option>
+                                <option value="2017">2017</option>
+                                <option value="2018">2018</option>
+                                <option value="2019">2019</option>
+                                <option value="2020">2020</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <select class="form-control" 　name="month">
+                                <option value="">-</option>
+                                <option value="1">1</option>
+                                <option value="2">2</option>
+                                <option value="3">3</option>
+                                <option value="4">4</option>
+                                <option value="5">5</option>
+                                <option value="6">6</option>
+                                <option value="7">7</option>
+                                <option value="8">8</option>
+                                <option value="9">9</option>
+                                <option value="10">10</option>
+                                <option value="11">11</option>
+                                <option value="12">12</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <select class="form-control" 　name="day">
+                                <option value="">-</option>
+                                <option value="1">1</option>
+                                <option value="2">2</option>
+                                <option value="3">3</option>
+                                <option value="4">4</option>
+                                <option value="5">5</option>
+                                <option value="6">6</option>
+                                <option value="7">7</option>
+                                <option value="8">8</option>
+                                <option value="9">9</option>
+                                <option value="10">10</option>
+                                <option value="11">11</option>
+                                <option value="12">12</option>
+                                <option value="13">13</option>
+                                <option value="14">14</option>
+                                <option value="15">15</option>
+                                <option value="16">16</option>
+                                <option value="17">17</option>
+                                <option value="18">18</option>
+                                <option value="19">19</option>
+                                <option value="20">20</option>
+                                <option value="21">21</option>
+                                <option value="22">22</option>
+                                <option value="23">23</option>
+                                <option value="24">24</option>
+                                <option value="25">25</option>
+                                <option value="26">26</option>
+                                <option value="27">27</option>
+                                <option value="28">28</option>
+                                <option value="29">29</option>
+                                <option value="30">30</option>
+                                <option value="31">31</option>
+                            </select>
+
+                        </div>
+
+                    </div>
+                    <div class="kaiinjouhou_update_button1">
+                        <!-- onclickで、まずはbutton_click1のファンクションを実行。その後switchingのファンクションへnoneを引数として渡す -->
+                        <input id="kaiinjouhou_update_button1" class="btn btn-secondary" type="button" value="登録なしへ変更" onclick="button_click1();switching()">
+                    </div>
+
+                    <div class="container ">
+                        <a href="kaiinjouhou_update_C.html " class="add-submit " id=" ">確認する</a><br>
+                    </div>
+                    <div class="container ">
+                        <a href="<?php base_url(); ?>/mypage" class="reset-submit " id=" ">キャンセル</a><br>
+                    </div>
+                </form>
+
+            </section>
+        </div>
+    </div><!--/#contents-->
+
+   <!-- フッター --><!--ページの上部に戻る「↑」ボタン-->
+   <?php $this->load->view('Layout/footer_view.php'); ?>  
+
+    <!-- jQuery -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script>
+        $(function() {
+            //初期表示を非表示にする
+            $('#none-form1').hide();
+            $('#kaiinjouhou-child2add').hide();
+        });
+    </script>
+
+
+</body>
+
+</html>

--- a/src/application/www/views/Mypage/mypage_view.php
+++ b/src/application/www/views/Mypage/mypage_view.php
@@ -1,0 +1,204 @@
+<!-- ******************************** -->
+<!-- ********   マイページ   ******** -->
+<!-- ******************************** -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>マイページ｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+        <!-- ロゴ --><!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>        
+
+        <!-- メインコンテンツ -->
+        <div id="contents">
+
+            <section class="box1">
+
+                <h2><span>マイページ</span></h2>
+                <div class="message-user">
+                    <p>こんにちは、<?= $users_parent_name; ?>さん</p>
+                </div>
+                <!-- タブ部分 -->
+                <div class="tab-wrap">
+                    <!-- こども１ -->
+                    <input id="tab01" type="radio" name="tab" class="tab-switch" checked="checked"><label class="tab-label" for="tab01"><img src="<?php base_url(); ?>/topdist/images/mypage_pen_icon.png"> 子どもなまえ➀</label>
+                    <div class="tab-content">
+                        <div class="fancy-button">
+                            <div class="left-frills frills"></div>
+                            <div class="button">
+                                <p>
+                                    <a href="<?php base_url(); ?>/mypage/stamppage"><img src="<?php base_url(); ?>/topdist/images/mypage_note_icon.png"> すたんぷちょう</a>
+                                </p>
+                            </div>
+                            <div class="right-frills frills"></div>
+                        </div>
+                        <h1 class="mypage-read">プリント</h1>
+                        <table cellpadding="0" cellspacing="10" align="center">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <img src="<?php base_url(); ?>/topdist/images/hiragana.png" alt="ひらがなプリント" width="300" height="">
+                                    </td>
+                                    <td>
+                                        <a href="<?php base_url(); ?>/mypage/hiragana" class="btn btn-malformation1">「ひらがな」を印刷</a>
+                                    </td>
+                                    <td>
+                                        <img src="<?php base_url(); ?>/topdist/images/suzi.png" alt="すうじプリント" width="300" height=""></p>
+                                    </td>
+                                    <td>
+                                        <a href="<?php base_url(); ?>/mypage/suzi" class="btn btn-malformation2">「すうじ」を印刷</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <table cellpadding="0" cellspacing="30" align="center">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <img src="<?php base_url(); ?>/topdist/images/unpitsu.png" alt="ひらがなプリント" width="300" height="">
+                                    </td>
+                                    <td>
+                                        <a href="<?php base_url(); ?>/mypage/unpitu" class="btn btn-malformation3">「運筆」を印刷</a>
+                                    </td>
+                                    <td>
+                                        <img src="<?php base_url(); ?>/topdist/images/tentunagi.png" alt="すうじプリント" width="300" height=""></p>
+                                    </td>
+                                    <td>
+                                        <a href="<?php base_url(); ?>/mypage/tentunagi" class="btn btn-malformation4">「点つなぎ」を印刷</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <table cellpadding="0" cellspacing="20" align="center">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <img src="<?php base_url(); ?>/topdist/images/programming.png" alt="ひらがなプリント" width="300" height="">
+                                    </td>
+                                    <td>
+                                        <a href="<?php base_url(); ?>/mypage/programming" class="btn btn-malformation5">「プログラミング」を印刷</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <!-- こども２ -->
+                    <input id="tab02" type="radio" name="tab" class="tab-switch"><label class="tab-label" for="tab02"><img src="<?php base_url(); ?>/topdist/images/mypage_pen_icon.png"> 子どもなまえ➁</label>
+                    <div class="tab-content">
+                        <div class="fancy-button">
+                            <div class="left-frills frills"></div>
+                            <div class="button">
+                                <p>
+                                    <a href="<?php base_url(); ?>/mypage/stamppage2"><img src="<?php base_url(); ?>/topdist/images/mypage_note_icon.png"> すたんぷちょう</a>
+                                </p>
+                            </div>
+                            <div class="right-frills frills"></div>
+                        </div>
+                        <h1 class="mypage-read">プリント</h1>
+
+                        <table cellpadding="0" cellspacing="10" align="center">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <img src="<?php base_url(); ?>/topdist/images/hiragana.png" alt="ひらがなプリント" width="300" height="">
+                                    </td>
+                                    <td>
+                                        <a href="<?php base_url(); ?>/mypage/hiragana" class="btn btn-malformation1">「ひらがな」を印刷</a>
+                                    </td>
+                                    <td>
+                                        <img src="<?php base_url(); ?>/topdist/images/suzi.png" alt="すうじプリント" width="300" height=""></p>
+                                    </td>
+                                    <td>
+                                        <a href="<?php base_url(); ?>/mypage/suzi" class="btn btn-malformation2">「すうじ」を印刷</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <table cellpadding="0" cellspacing="30" align="center">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <img src="<?php base_url(); ?>/topdist/images/unpitsu.png" alt="ひらがなプリント" width="300" height="">
+                                    </td>
+                                    <td>
+                                        <a href="<?php base_url(); ?>/mypage/unpitu" class="btn btn-malformation3">「運筆」を印刷</a>
+                                    </td>
+                                    <td>
+                                        <img src="<?php base_url(); ?>/topdist/images/tentunagi.png" alt="すうじプリント" width="300" height=""></p>
+                                    </td>
+                                    <td>
+                                        <a href="<?php base_url(); ?>/mypage/tentunagi" class="btn btn-malformation4">「点つなぎ」を印刷</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <table cellpadding="0" cellspacing="20" align="center">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <img src="<?php base_url(); ?>/topdist/images/programming.png" alt="ひらがなプリント" width="300" height="">
+                                    </td>
+                                    <td>
+                                        <a href="<?php base_url(); ?>/mypage/programming" class="btn btn-malformation5">「プログラミング」を印刷</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                    </div>
+
+                    <!-- 会員情報・ログアウト -->
+                    <input id="tab03" type="radio" name="tab" class="tab-switch"><label class="tab-label" for="tab03"><img src="<?php base_url(); ?>/topdist/images/mypage_settei_icon.png"> 会員情報 / ログアウト</label>
+                    <div class="tab-content">
+                        <section class="member">
+                            <h1 class="mypage-read">会員情報</h1>
+                            <ul>
+                                <li>
+                                    <a href="<?php base_url(); ?>/mypage/kaiinjouhou_update" class="btn btn--orange"><img src="<?php base_url(); ?>/topdist/images/mypage_touroku_icon.png">
+                                        <br>
+                                        <br>会員情報の変更</a>
+                                </li>
+                                <li>
+                                    <a href="<?php base_url(); ?>/mypage/passwordchange" class="btn btn--orange"><img src="<?php base_url(); ?>/topdist/images/mypage_password_icon.png">
+                                        <br>
+                                        <br>パスワードの変更</a>
+                                </li>
+                                <li>
+                                    <a href="<?php base_url(); ?>/mypage/taikai" class="btn btn--orange"><img src="<?php base_url(); ?>/topdist/images/mypage_taikai_icon.png">
+                                        <br>
+                                        <br>退会</a>
+                                </li>
+                                <li>
+                                    <a href="index.html" class="btn btn--orange"><img src="<?php base_url(); ?>/topdist/images/mypage_logout_icon.png">
+                                        <br>
+                                        <br>ログアウト</a>
+                                </li>
+                            </ul>
+                        </section>
+
+                    </div>
+                </div>
+            </section>
+
+        </div><!--/#contents-->
+
+        <!-- フッター --><!--ページの上部に戻る「↑」ボタン-->
+        <?php $this->load->view('Layout/footer_view.php'); ?>  
+
+    <script src="<?php base_url(); ?>/topdist/js/fixmenu_pagetop.js"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+</body>
+
+</html>

--- a/src/application/www/views/Mypage/passwordchange_view.php
+++ b/src/application/www/views/Mypage/passwordchange_view.php
@@ -1,0 +1,73 @@
+<!-- ********************************** -->
+<!-- *******  パスワードの変更  ******* -->
+<!-- ********************************** -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>パスワードの変更｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+
+        <!-- ロゴ -->
+        <!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <h1 class="contCaption">PASSWORD</h1>
+                <h2 class="contSubCaption">パスワードの変更</h2>
+                <div class="message-user-kaiin">
+                    <p>パスワードの変更を行います。<br>各項目の入力がおすみになりましたら「変更する」ボタンを押して完了ページへお進みください。</p>
+                </div>
+
+                <!-- パスワード変更フォーム -->
+                <form action="" class="">
+                    <div class="form-group row form-inline justify-content-center">
+                        <label for="OldPassword" class="col-sm-2 col-form-label">現在のパスワード</label>
+                        <div class="col-xs-2">
+                            <input type="password" class="form-control" id="OldPassword" placeholder="Password">
+                            <small id="passwordHelp" class="form-text text-muted">半角英数字のみ6文字以上で入力ください</small>
+                        </div>
+                    </div>
+
+                    <div class="form-group row form-inline justify-content-center">
+                        <label for="NewPassword" class="col-sm-2 col-form-label">新しいパスワード</label>
+                        <div class="col-xs-3">
+                            <input type="password" class="form-control" id="NewPassword" placeholder="Password">
+                            <small id="passwordHelp" class="form-text text-muted">半角英数字のみ6文字以上で入力ください</small>
+                        </div>
+                    </div>
+                    <div class="form-group row form-inline justify-content-center">
+                        <label for="NewPassword-C" class="col-sm-2 col-form-label">新しいパスワード(確認用)</label>
+                        <div class="col-xs-3">
+                            <input type="password" class="form-control" id="NewPassword-C" placeholder="Password">
+                            <small id="passwordHelp" class="form-text text-muted">半角英数字のみ6文字以上で入力ください</small>
+                        </div>
+                    </div>
+                </form>
+
+                <div class="container ">
+                    <a href="passwordchangekanryo.html " class="add-submit " id=" ">変更する</a><br>
+                </div>
+                <div class="container ">
+                    <a href="<?php base_url(); ?>/mypage" class="reset-submit " id=" ">戻る</a><br>
+                </div>
+
+            </section>
+
+        </div><!--/#contents-->
+
+        <!-- フッター --><!--ページの上部に戻る「↑」ボタン-->
+        <?php $this->load->view('Layout/footer_view.php'); ?>
+
+</body>
+
+</html>

--- a/src/application/www/views/Mypage/passwordchangekanryo_view.php
+++ b/src/application/www/views/Mypage/passwordchangekanryo_view.php
@@ -1,0 +1,56 @@
+<!-- ************************************ -->
+<!-- ****  パスワード変更完了ページ  **** -->
+<!-- ************************************ -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>パスワード変更完了｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+
+        <!-- ロゴ --><!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <h1 class="contCaption">MY DATA　UPDATE</h1>
+                <h2 class="contSubCaption">パスワードの変更完了</h2>
+                <div class="message-user-kaiin">
+                    <p>パスワードの変更が完了いたしました。 <br> ご登録いただきましたメールアドレス宛に変更完了メールを送信させていただいております。
+                    </p>
+                    <p>※10分ほど経過してもメールが届かない場合、以下の可能性があります。</p>
+                    <ul>
+                        <li>*迷惑メールなどの受信設定をされている</li>
+                        <li>*メールサーバーが混み合っている </li>
+                        <li>*登録されたメールアドレスに間違いがある</li>
+                    </ul>
+                </div>
+                <div class="sectionInner2">
+
+                    <form action="#" method="post">
+                        <div class="tourokujouhou">
+
+                            <div class="container">
+                                <a href="<?php base_url(); ?>/mypage" class="reset-submit" id="">マイページへ</a><br>
+                            </div><!-- sectionInner -->
+                        </div>
+                </div>
+                </form>
+
+            </section>
+        </div><!--/#contents-->
+
+    <!-- フッター --><!--ページの上部に戻る「↑」ボタン-->
+    <?php $this->load->view('Layout/footer_view.php'); ?>  
+
+</body>
+
+</html>

--- a/src/application/www/views/Mypage/stamppage2_view.php
+++ b/src/application/www/views/Mypage/stamppage2_view.php
@@ -1,0 +1,535 @@
+<!-- ******************************** -->
+<!-- *****   スタンプページ２   ***** -->
+<!-- ******************************** -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>○○ちゃんのすたんぷちょう｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+
+        <!-- ロゴ -->
+        <!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <h2><span></span>〇〇ちゃんのすたんぷちょう</span>
+                </h2>
+                <div class="stampimghead">
+                    <p><img src="<?php base_url(); ?>/topdist/images/stamp3.png" alt="スタンプサンプル画像2"></p>
+                </div>
+                <!-- ひらがな -->
+                <table class="osare5-table col5t">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>あ</th>
+                            <th>い</th>
+                            <th>う</th>
+                            <th>え</th>
+                            <th>お</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana">ひらがな</th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                        <thead>
+                    </tbody>
+                    <tr>
+                        <th class="table-th-hiragana-space"></th>
+                        <th>か</th>
+                        <th>き</th>
+                        <th>く</th>
+                        <th>け</th>
+                        <th>こ</th>
+
+                    </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>さ</th>
+                            <th>し</th>
+                            <th>す</th>
+                            <th>せ</th>
+                            <th>そ</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>た</th>
+                            <th>ち</th>
+                            <th>つ</th>
+                            <th>て</th>
+                            <th>と</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+
+                        <thead>
+                            <tr>
+                                <th class="table-th-hiragana-space"></th>
+                                <th>な</th>
+                                <th>に</th>
+                                <th>ぬ</th>
+                                <th>ね</th>
+                                <th>の</th>
+
+                            </tr>
+                        </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>は</th>
+                            <th>ひ</th>
+                            <th>ふ</th>
+                            <th>へ</th>
+                            <th>ほ</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>ま</th>
+                            <th>み</th>
+                            <th>む</th>
+                            <th>め</th>
+                            <th>も</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>や</th>
+                            <th></th>
+                            <th>ゆ</th>
+                            <th></th>
+                            <th>よ</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td></td>
+                            <td></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td></td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>ら</th>
+                            <th>り</th>
+                            <th>る</th>
+                            <th>れ</th>
+                            <th>ろ</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>わ</th>
+                            <th></th>
+                            <th>を</th>
+                            <th></th>
+                            <th>ん</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td></td>
+                            <td></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td></td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+
+                </table>
+                <div class="stampimgline">
+                    <img src="<?php base_url(); ?>/topdist/images/stamp6.png" alt="スタンプサンプル画像6">
+                </div>
+
+                <!-- 数字 -->
+                <table class="osare5-table col5t">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>0</th>
+                            <th>1</th>
+                            <th>2</th>
+                            <th>3</th>
+                            <th>4</th>
+                            <th>5</th>
+                            <th>6</th>
+                            <th>7</th>
+                            <th>8</th>
+                            <th>9</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana">すうじ</th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+
+                </table>
+                <div class="stampimgline">
+                    <img src="<?php base_url(); ?>/topdist/images/stamp6.png" alt="スタンプサンプル画像6">
+                </div>
+
+                <!-- 運筆 -->
+                <table class="osare5-table col5t">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>1</th>
+                            <th>2</th>
+                            <th>3</th>
+                            <th>4</th>
+                            <th>5</th>
+                            <th>6</th>
+                            <th>7</th>
+                            <th>8</th>
+                            <th>9</th>
+                            <th>10</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana">うんぴつ</th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <div class="stampimgline">
+                    <img src="<?php base_url(); ?>/topdist/images/stamp6.png" alt="スタンプサンプル画像6">
+                </div>
+
+                <!-- 点つなぎ -->
+                <table class="osare5-table col5t">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>1</th>
+                            <th>2</th>
+                            <th>3</th>
+                            <th>4</th>
+                            <th>5</th>
+                            <th>6</th>
+                            <th>7</th>
+                            <th>8</th>
+                            <th>9</th>
+                            <th>10</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana">てんつなぎ</th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <div class="stampimgline">
+                    <img src="<?php base_url(); ?>/topdist/images/stamp6.png" alt="スタンプサンプル画像6">
+                </div>
+
+                <!-- プログラミング -->
+                <table class="osare5-table col5t">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>1</th>
+                            <th>2</th>
+                            <th>3</th>
+                            <th>4</th>
+                            <th>5</th>
+                            <th>6</th>
+                            <th>7</th>
+                            <th>8</th>
+                            <th>9</th>
+                            <th>10</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana">プログラミング</th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th>11</th>
+                                <th>12</th>
+                                <th>13</th>
+                                <th>14</th>
+                                <th>15</th>
+                                <th>16</th>
+                                <th>17</th>
+                                <th>18</th>
+                                <th>19</th>
+                                <th>20</th>
+                            </tr>
+                        </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiraganaspace"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+
+        </div>
+        <!--/#contents-->
+
+        <!-- フッター -->
+        <!--ページの上部に戻る「↑」ボタン-->
+        <?php $this->load->view('Layout/footer_view.php'); ?>
+
+</body>
+
+</html>

--- a/src/application/www/views/Mypage/stamppage_view.php
+++ b/src/application/www/views/Mypage/stamppage_view.php
@@ -1,0 +1,535 @@
+<!-- ******************************** -->
+<!-- *****   スタンプページ１   ***** -->
+<!-- ******************************** -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>○○ちゃんのすたんぷちょう｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+
+        <!-- ロゴ -->
+        <!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <h2><span></span>〇〇ちゃんのすたんぷちょう</span>
+                </h2>
+                <div class="stampimghead">
+                    <p><img src="<?php base_url(); ?>/topdist/images/stamp3.png" alt="スタンプサンプル画像2"></p>
+                </div>
+                <!-- ひらがな -->
+                <table class="osare5-table col5t">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>あ</th>
+                            <th>い</th>
+                            <th>う</th>
+                            <th>え</th>
+                            <th>お</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana">ひらがな</th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                        <thead>
+                    </tbody>
+                    <tr>
+                        <th class="table-th-hiragana-space"></th>
+                        <th>か</th>
+                        <th>き</th>
+                        <th>く</th>
+                        <th>け</th>
+                        <th>こ</th>
+
+                    </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>さ</th>
+                            <th>し</th>
+                            <th>す</th>
+                            <th>せ</th>
+                            <th>そ</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>た</th>
+                            <th>ち</th>
+                            <th>つ</th>
+                            <th>て</th>
+                            <th>と</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+
+                        <thead>
+                            <tr>
+                                <th class="table-th-hiragana-space"></th>
+                                <th>な</th>
+                                <th>に</th>
+                                <th>ぬ</th>
+                                <th>ね</th>
+                                <th>の</th>
+
+                            </tr>
+                        </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>は</th>
+                            <th>ひ</th>
+                            <th>ふ</th>
+                            <th>へ</th>
+                            <th>ほ</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>ま</th>
+                            <th>み</th>
+                            <th>む</th>
+                            <th>め</th>
+                            <th>も</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>や</th>
+                            <th></th>
+                            <th>ゆ</th>
+                            <th></th>
+                            <th>よ</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td></td>
+                            <td></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td></td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>ら</th>
+                            <th>り</th>
+                            <th>る</th>
+                            <th>れ</th>
+                            <th>ろ</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <th>わ</th>
+                            <th></th>
+                            <th>を</th>
+                            <th></th>
+                            <th>ん</th>
+
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana-space"></th>
+                            <td></td>
+                            <td></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td></td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+
+                </table>
+                <div class="stampimgline">
+                    <img src="<?php base_url(); ?>/topdist/images/stamp6.png" alt="スタンプサンプル画像6">
+                </div>
+
+                <!-- 数字 -->
+                <table class="osare5-table col5t">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>0</th>
+                            <th>1</th>
+                            <th>2</th>
+                            <th>3</th>
+                            <th>4</th>
+                            <th>5</th>
+                            <th>6</th>
+                            <th>7</th>
+                            <th>8</th>
+                            <th>9</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana">すうじ</th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+
+                </table>
+                <div class="stampimgline">
+                    <img src="<?php base_url(); ?>/topdist/images/stamp6.png" alt="スタンプサンプル画像6">
+                </div>
+
+                <!-- 運筆 -->
+                <table class="osare5-table col5t">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>1</th>
+                            <th>2</th>
+                            <th>3</th>
+                            <th>4</th>
+                            <th>5</th>
+                            <th>6</th>
+                            <th>7</th>
+                            <th>8</th>
+                            <th>9</th>
+                            <th>10</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana">うんぴつ</th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <div class="stampimgline">
+                    <img src="<?php base_url(); ?>/topdist/images/stamp6.png" alt="スタンプサンプル画像6">
+                </div>
+
+                <!-- 点つなぎ -->
+                <table class="osare5-table col5t">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>1</th>
+                            <th>2</th>
+                            <th>3</th>
+                            <th>4</th>
+                            <th>5</th>
+                            <th>6</th>
+                            <th>7</th>
+                            <th>8</th>
+                            <th>9</th>
+                            <th>10</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana">てんつなぎ</th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <div class="stampimgline">
+                    <img src="<?php base_url(); ?>/topdist/images/stamp6.png" alt="スタンプサンプル画像6">
+                </div>
+
+                <!-- プログラミング -->
+                <table class="osare5-table col5t">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>1</th>
+                            <th>2</th>
+                            <th>3</th>
+                            <th>4</th>
+                            <th>5</th>
+                            <th>6</th>
+                            <th>7</th>
+                            <th>8</th>
+                            <th>9</th>
+                            <th>10</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiragana">プログラミング</th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th>11</th>
+                                <th>12</th>
+                                <th>13</th>
+                                <th>14</th>
+                                <th>15</th>
+                                <th>16</th>
+                                <th>17</th>
+                                <th>18</th>
+                                <th>19</th>
+                                <th>20</th>
+                            </tr>
+                        </thead>
+                    <tbody>
+                        <tr>
+                            <th class="table-th-hiraganaspace"></th>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td><img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5"></td>
+                            <td>
+                                <div class="ribbon19-wrapper">
+                                    <div class="ribbon19-content">
+                                        <span class="ribbon19">NEW</span>
+                                    </div>
+                                    <img src="<?php base_url(); ?>/topdist/images/stamp5.png" alt="スタンプサンプル画像5">
+                                </div>
+                            </td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+
+        </div>
+        <!--/#contents-->
+
+        <!-- フッター -->
+        <!--ページの上部に戻る「↑」ボタン-->
+        <?php $this->load->view('Layout/footer_view.php'); ?>
+
+</body>
+
+</html>

--- a/src/application/www/views/Mypage/taikai_view.php
+++ b/src/application/www/views/Mypage/taikai_view.php
@@ -1,0 +1,46 @@
+<!-- ******************************** -->
+<!-- ********      退会      ******** -->
+<!-- ******************************** -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>退会｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+
+        <!-- ロゴ -->
+        <!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <!-- <form action="#" method="post"> -->
+                <h1 class="contCaption">WITHDRAWAL</h1>
+                <h2 class="contSubCaption">退会</h2>
+                <p class="message-user-kaiin">退会されますと、お預かりしているご登録情報を全て消去いたします。<br>「退会する」ボタンを押して退会ページへお進みください。</p>
+
+                <div class="container">
+                    <a href="taikaikanryo.html" class="add-submit " id=" ">退会する</a><br>
+                </div>
+                <div class="container ">
+                    <a href="<?php base_url(); ?>/mypage" class="reset-submit " id=" ">戻る</a><br>
+                </div>
+
+            </section>
+
+        </div><!--/#contents-->
+
+    <!-- フッター --><!--ページの上部に戻る「↑」ボタン-->
+    <?php $this->load->view('Layout/footer_view.php'); ?>  
+
+</body>
+
+</html>

--- a/src/application/www/views/Mypage/taikaikanryo_view.php
+++ b/src/application/www/views/Mypage/taikaikanryo_view.php
@@ -1,0 +1,40 @@
+<!-- ******************************** -->
+<!-- ********    退会完了    ******** -->
+<!-- ******************************** -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+
+        <!-- ロゴ --><!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>        
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <h1 class="contCaption">THAK YOU</h1>
+                <h2 class="contSubCaption">退会完了</h2>
+                <p class="message-user-kaiin">ご利用ありがとうございました。</p>
+
+                <div class="container">
+                    <a href="<?php base_url(); ?>/top" class="reset-submit" id="">HOMEへ</a><br>
+                </div>
+
+            </section>
+
+        </div><!--/#contents-->
+
+    <!-- フッター --><!--ページの上部に戻る「↑」ボタン-->
+    <?php $this->load->view('Layout/footer_view.php'); ?>  
+</body>
+
+</html>

--- a/src/application/www/views/Mypage_print/hiragana_view.php
+++ b/src/application/www/views/Mypage_print/hiragana_view.php
@@ -1,0 +1,214 @@
+<!-- ******************************** -->
+<!-- *****  ひらがな印刷ページ  ***** -->
+<!-- ******************************** -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>ひらがな｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+
+        <!-- ロゴ --><!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>   
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <h2><span>ひらがな印刷ページ</span></h2>
+
+                <p>クリックすると印刷ページ(PDFファイル)が開きます</p>
+
+                <h3>あいうえお</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                </div>
+                <br>
+                <h3>かきくけこ</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                </div>
+                <br>
+                <h3>さしすせそ</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                </div>
+                <br>
+                <h3>たちつてと</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                </div>
+                <br>
+                <h3>なにぬねの</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                </div>
+                <br>
+                <h3>はひふへほ</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                </div>
+                <br>
+                <h3>まみむめも</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                </div>
+                <br>
+                <h3>やゆよ</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                </div>
+                <br>
+                <h3>らりるれろ</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                </div>
+                <br>
+                <h3>わをん</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eedde8">
+                    </a>
+                </div>
+                <br>
+
+        </div><!--/#contents-->
+
+        <!-- フッター --><!--ページの上部に戻る「↑」ボタン-->
+        <?php $this->load->view('Layout/footer_view.php'); ?>  
+
+</body>
+
+</html>

--- a/src/application/www/views/Mypage_print/programming_view.php
+++ b/src/application/www/views/Mypage_print/programming_view.php
@@ -1,0 +1,112 @@
+<!-- ************************************ -->
+<!-- ****  プログラミング印刷ページ  **** -->
+<!-- ************************************ -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>プログラミング｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+
+        <!-- ロゴ --><!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>        
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <h2><span>ぷろぐらみんぐ印刷ページ</span></h2>
+
+                <p>クリックすると印刷ページ(PDFファイル)が開きます</p>
+
+                <h3>１</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                </div>
+                <br>
+                <h3>２</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                </div>
+                <br>
+                <h3>３</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                </div>
+                <br>
+                <h3>４</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #d790ec">
+                    </a>
+                </div>
+                <br>
+
+        </div><!--/#contents-->
+
+       <!-- フッター --><!--ページの上部に戻る「↑」ボタン-->
+       <?php $this->load->view('Layout/footer_view.php'); ?>  
+
+</body>
+
+</html>

--- a/src/application/www/views/Mypage_print/suzi_view.php
+++ b/src/application/www/views/Mypage_print/suzi_view.php
@@ -1,0 +1,73 @@
+<!-- ******************************** -->
+<!-- ******   すうじ印刷ページ   **** -->
+<!-- ******************************** -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>すうじ｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+
+        <!-- ロゴ --><!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>        
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <h2><span>すうじ印刷ページ</span></h2>
+
+                <p>クリックすると印刷ページ(PDFファイル)が開きます</p>
+
+                <h3>0～4</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #c6ecf0">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #c6ecf0">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #c6ecf0">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #c6ecf0">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #c6ecf0">
+                    </a>
+                </div>
+                <br>
+                <h3>5～9</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #c6ecf0">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #c6ecf0">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #c6ecf0">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #c6ecf0">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #c6ecf0">
+                    </a>
+                </div>
+
+        </div><!--/#contents-->
+
+       <!-- フッター --><!--ページの上部に戻る「↑」ボタン-->
+       <?php $this->load->view('Layout/footer_view.php'); ?>  
+
+</body>
+
+</html>

--- a/src/application/www/views/Mypage_print/tentunagi_view.php
+++ b/src/application/www/views/Mypage_print/tentunagi_view.php
@@ -1,0 +1,72 @@
+<!-- ******************************** -->
+<!-- *****   点つなぎ印刷ページ  **** -->
+<!-- ******************************** -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>てんつなぎ｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+
+        <!-- ロゴ --><!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <h2><span>点つなぎ印刷ページ</span></h2>
+
+                <p>クリックすると印刷ページ(PDFファイル)が開きます</p>
+
+                <h3>15まで</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eceb8d">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eceb8d">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eceb8d">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eceb8d">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eceb8d">
+                    </a>
+                </div>
+                <br>
+                <h3>30まで</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eceb8d">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eceb8d">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eceb8d">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eceb8d">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #eceb8d">
+                    </a>
+                </div>
+
+        </div><!--/#contents-->
+
+    <!-- フッター --><!--ページの上部に戻る「↑」ボタン-->
+    <?php $this->load->view('Layout/footer_view.php'); ?>  
+</body>
+
+</html>

--- a/src/application/www/views/Mypage_print/unpitu_view.php
+++ b/src/application/www/views/Mypage_print/unpitu_view.php
@@ -1,0 +1,73 @@
+<!-- ******************************** -->
+<!-- ****   うんぴつ印刷ページ   **** -->
+<!-- ******************************** -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <title>うんぴつ｜幼児無料プリントサイト ぷちはぐ</title>
+    <!-- head共通 -->
+    <?php $this->load->view('Layout/header_view'); ?>
+</head>
+
+<body>
+
+    <div id="container">
+
+        <!-- ロゴ --><!-- メインメニュー -->
+        <?php $this->load->view('Layout/menu_view.php'); ?>        
+
+        <div id="contents">
+
+            <section class="box1">
+
+                <h2><span>うんぴつ印刷ページ</span></h2>
+
+                <p>クリックすると印刷ページ(PDFファイル)が開きます</p>
+
+                <h3>かんたん</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #baeebe">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #baeebe">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #baeebe">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #baeebe">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #baeebe">
+                    </a>
+                </div>
+                <br>
+                <h3>チャレンジ</h3>
+                <div class="box">
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #baeebe">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #baeebe">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #baeebe">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #baeebe">
+                    </a>
+                    <a href="images/a.pdf" target="_blank">
+                        <img src="<?php base_url(); ?>/topdist/images/a.png" alt="ひらがな「あ」" hspace="10" vspace="10" style="border:solid 5px #baeebe">
+                    </a>
+                </div>
+
+        </div><!--/#contents-->
+
+    <!-- フッター --><!--ページの上部に戻る「↑」ボタン-->
+    <?php $this->load->view('Layout/footer_view.php'); ?>  
+
+</body>
+
+</html>


### PR DESCRIPTION
マイページ以降の画面（マップの赤いところ）のHTMLをcodeIgniterへ移行しました。
【主な変更点】
コントローラー
・Mypage.phpを作成
モデル
・Mypage_model.phpを作成
ビュー
・MypageとMypage_printフォルダを作成しその中に各ページを移行
・Layoutにhead、メインメニュー、footer部分を共通化

確認お願いします。